### PR TITLE
Update Sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "boom": "^3.1.1",
     "bower": "^1.7.2",
     "handlebars": "^4.0.5",
-    "hapi": "^12.0.0",
+    "hapi": "^12.0.1",
     "hapi-auth-basic": "^4.1.0",
     "inert": "^3.2.0",
     "joi": "^7.1.0",
     "moment": "^2.11.0",
     "mysql": "^2.10.0",
-    "sequelize": "^3.16.0",
+    "sequelize": "^3.17.1",
     "vision": "^4.0.1"
   },
   "optionalDependencies": {
@@ -62,7 +62,7 @@
     "pm2": "^1.0.0",
     "read": "^1.0.7",
     "remark": "^3.1.3",
-    "remark-lint": "^2.0.2",
+    "remark-lint": "^2.0.3",
     "remark-slug": "^3.0.1",
     "remark-validate-links": "^2.0.2",
     "stylelint": "^3.2.0"


### PR DESCRIPTION
* Resolves [critical security warning](https://github.com/sequelize/sequelize/releases/tag/v3.17.0) for Sequelize
* Also updates `hapi` and `remark-lint`