### PR TITLE
Update Node Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "boom": "^3.1.2",
     "bower": "^1.7.6",
     "handlebars": "^4.0.5",
-    "hapi": "^12.1.0",
+    "hapi": "^13.0.0",
     "hapi-auth-basic": "^4.1.0",
     "inert": "^3.2.0",
     "joi": "^7.2.3",
     "moment": "^2.11.1",
     "mysql": "^2.10.2",
-    "sequelize": "^3.18.0",
+    "sequelize": "^3.19.0",
     "vision": "^4.0.1"
   },
   "optionalDependencies": {
@@ -68,7 +68,7 @@
     "remark-lint": "^2.2.1",
     "remark-slug": "^4.0.0",
     "remark-validate-links": "^2.0.2",
-    "stylelint": "^4.1.0"
+    "stylelint": "^4.2.0"
   },
   "engines": {
     "node": ">=4.0.0",


### PR DESCRIPTION
Hapi now requires 32 characters for encrypting secret keys.
Current password system uses bcrypt and should be unaffected.
This will affect when we move to a separate login page and will probably use [auth-cookie](https://github.com/hapijs/hapi-auth-cookie).

Sequelize and Stylelint have general bug fixes.