### PR TITLE
use Pull Approve

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 1
-pattern = "(?i)LGTM|:shipit:"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -7,4 +7,5 @@ reviewers:
     required: 1
     members:
         - ChristianMurphy
+        - kgary
         - poojaRal

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,10 @@
+approve_by_comment: true
+approve_regex: '^(LGTM|:shipit:|:+1:)'
+reject_regex: '^:-1:'
+reset_on_push: true
+author_approval: ignored
+reviewers:
+    required: 1
+    members:
+        - ChristianMurphy
+        - poojaRal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@
 3. Get a code review
 
    * Reviewers are listed in `MAINTAINERS`
-   * A reviewer can approve a PR by commenting `LGTM` or `:shipit:`
+   * A reviewer can approve a PR by writing a comment starting with `:+1:`, `LGTM`, or `:shipit:`
+   * A review can reject a PR by writing a comment starting with `:-1:`
 
 4. Merge
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,0 @@
-ChristianMurphy
-poojaRal


### PR DESCRIPTION
Switching LGTM.co for Pull Approve because:

1. Pull Approve allows rejecting a Pull Request
2. Pull Approve allows author to be ignored in reviews
3. Pull Approve allows groups of reviewers