### PR TITLE
Add `lint-fix` task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,12 @@
 
    * Test results are reported to [PR status](https://github.com/blog/1935-see-results-from-all-pull-request-status-checks)
    * Tests can be run locally using `npm run lint` and `npm run test`
+   * Some lint errors can automatically resolved by running `npm run lint-fix`
    * Disabling tests is not fixing them
 
 3. Get a code review
 
-   * Reviewers are listed in `MAINTAINERS`
+   * Reviewers are listed in `.pullapprove.yml`
    * A reviewer can approve a PR by writing a comment starting with `:+1:`, `LGTM`, or `:shipit:`
    * A review can reject a PR by writing a comment starting with `:-1:`
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@
 2. open the `documentation` folder in a file explorer
 3. open `index.html` in a browser
 
+## Additional Guides
+
+* [Contributing](CONTRIBUTING.md)
+* [Design](DESIGN.md)
+
 ## Tasks
 
 Tasks can be run by calling `npm run <task>`
@@ -56,6 +61,7 @@ Tasks can be run by calling `npm run <task>`
 * `documentation` generate code documentation
 * `init` create a server configuration file
 * `lint` lint check project files
+* `lint-fix` auto fixes some lint errors
 * `log` view server log
 * `outdated` view outdated server and browser packages
 * `seed` fill database with sample data

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "init": "node task/init",
     "postinstall": "bower install",
     "lint": "eslint . view/**/*.hbs --inline-config=false && remark *.md && stylelint view/stylesheet/*.css",
+    "lint-fix": "eslint . --fix --inline-config=false",
     "log": "pm2 logs",
     "outdated": "npm outdated && bower list",
     "preseed": "node task/sync",


### PR DESCRIPTION
Adds a `lint-fix` task that can automatically fix some lint errors.
Adds information about task to README and CONTRIBUTING
Updates file where reviewers are listed
Adds links to other guides from README