### PR TITLE
Automatically expire past due survey instances

### DIFF
--- a/rule/task/expire-survey-instances.js
+++ b/rule/task/expire-survey-instances.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * @module rule/task/expire-survey-instances
+ */
+
+const database = require('../../model');
+
+/**
+ * Finds all survey instances where the end time has passed, and changes state to 'expired'
+ * @returns {Promise<Array<Number, Array<Object>>>} Resolves to number of affected rows and the rows themselves
+ */
+function expireSurveyInstances () {
+    const surveyInstance = database.sequelize.model('survey_instance');
+
+    return surveyInstance.update(
+        {
+            state: 'expired'
+        },
+        {
+            where: {
+                $and: [
+                    {
+                        endTime: {
+                            $lt: new Date()
+                        }
+                    },
+                    {
+                        $or: [
+                            {
+                                state: 'pending'
+                            },
+                            {
+                                state: 'in progress'
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    );
+}
+
+module.exports = expireSurveyInstances;

--- a/rule/task/run-survey-rules.js
+++ b/rule/task/run-survey-rules.js
@@ -13,12 +13,9 @@ const one = 1;
 /**
  * Runs rules for all patients in all trials for all stages.
  * Rules will generate Survey Instances that open the same day the rule engine is run.
- * @param {Object} configuration - database configuration
  * @returns {Promise} resolves when completed
  */
-function runSurveyRules (configuration) {
-    database.setup(configuration);
-
+function runSurveyRules () {
     return database
     .sequelize
     .query(

--- a/task/helper/start-scheduler.js
+++ b/task/helper/start-scheduler.js
@@ -3,12 +3,14 @@
 /**
  * @module task/helper/start-scheduler
  * Starts the scheduler in the console process.
- * This is a cron job for creating survey instances for all patients.
+ * This is a cron job for creating survey instances for all patients and expiring past due surveys.
  */
 
 const moment = require('moment');
 const configuration = require('../../config.json');
+const expireSurveyInstances = require('../../rule/task/expire-survey-instances');
 const runSurveyRules = require('../../rule/task/run-survey-rules');
+const database = require('../../model');
 
 const one = 1;
 const beforeMidnight = moment()
@@ -21,9 +23,29 @@ const afterMidnight = moment()
     .unix();
 const now = moment().unix();
 
-// Check if time is between 11:59p and 12:01a
-if (now > beforeMidnight || now < afterMidnight) {
-    runSurveyRules(configuration.database)
+// The scheduler is only supposed to run off a cron job
+// however this code will be triggered everytime the server is started
+// meaning survey instances can be generated when they should not be
+// this attempts to prevent that by checking if time is between 11:59p and 12:01a
+
+// Logically this looks at a single day
+// and looks for times before 12:01 or after 11:59
+// on a timeline this would look like
+//
+// 12:00 12:01 Today 11:59 12:00
+// |<=====O-------------O=====>|
+if (now < afterMidnight || now > beforeMidnight) {
+    database.setup(configuration.database);
+
+    expireSurveyInstances()
+    .then((data) => {
+        console.log(data[0], 'survey instances expired');
+    })
+    .catch((err) => {
+        console.error(err);
+    });
+
+    runSurveyRules()
     .then(() => {
         console.log('survey instances created on:', new Date());
     })


### PR DESCRIPTION
resolves #242

changes state on past due surveys to 'expired'
documents why there is a time check on the scheduler and how the time check works