### PR TITLE
Bug Fix for ordering the compliance chart data by instance start date

### DIFF
--- a/controller/handler/patient.js
+++ b/controller/handler/patient.js
@@ -45,6 +45,7 @@ function patientView (request, reply) {
                 JOIN survey_template AS srt
                 ON srt.id = si.surveyTemplateId
                 WHERE pa.pin = ?
+                ORDER BY si.startTime
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,


### PR DESCRIPTION
compliance chart dates are ordered
![screen shot 2016-03-06 at 7 51 50 pm](https://cloud.githubusercontent.com/assets/5720497/13559846/9274cec0-e3d5-11e5-9015-d7772572c42f.png)
 