### PR TITLE
Partial Donut Chart Fix

### DIFF
--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -107,10 +107,13 @@ function trialView (request, reply) {
                     return status.pin === patient.pin;
                 });
 
+                // collect the compliance status as well as expiredCount
                 if (patientStatus) {
-                    // collect the compliance status as well as expiredCount
                     patient.status = patientStatus.status;
                     patient.totalMissed = patientStatus.expiredCount;
+                } else {
+                    patient.status = 'Unknown';
+                    patient.totalMissed = 0;
                 }
 
                 return patient;

--- a/controller/helper/process-compliance-count.js
+++ b/controller/helper/process-compliance-count.js
@@ -6,27 +6,29 @@
 /**
  * A dashboard with an overview of a specific trial.
  * @param {Array<Object>} rows - aggregated survey information
- * @returns {Array<Number>} count of redCount, yellowCount and greenCount
+ * @returns {Array<Number>} number of non-compliant, semi-compliant and compliant patients
  */
 function processComplianceCount (rows) {
-    const zero = 0;
-    const redThreshold = 2;
-    const yellowThresholdBegin = 0;
-    const redIndex = 0;
-    const yellowIndex = 1;
-    const greenIndex = 2;
-    const compliance = [zero, zero, zero];
+    const nonCompliantThreshold = 2;
+    const semiCompliantThreshold = 0;
+    const compliance = {
+        compliant: 0,
+        semiCompliant: 0,
+        nonCompliant: 0
+    };
 
     for (const row of rows) {
-        if (row.expiredCount > redThreshold) {
-            compliance[redIndex] += 1;
-        } else if (row.expiredCount > yellowThresholdBegin && row.expiredCount <= redThreshold) {
-            compliance[yellowIndex] += 1;
+        console.log(row);
+        if (row.expiredCount > nonCompliantThreshold) {
+            compliance.nonCompliant += 1;
+        } else if (row.expiredCount > semiCompliantThreshold) {
+            compliance.semiCompliant += 1;
         } else {
-            compliance[greenIndex] += 1;
+            compliance.compliant += 1;
         }
     }
 
-    return compliance;
+    return [compliance.nonCompliant, compliance.semiCompliant, compliance.compliant];
 }
+
 module.exports = processComplianceCount;


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story:** 501

**Taiga Task(s):** 529

**What did you change?**
When there is no survey in the past week mark patient compliance as 'Unknown'.
This should reduce confusion on why not all patients are rendered on the donut chart.
In the future we will will probably need to rework the metric used to calculate compliance for the chart.

**How can we test?**
View the trial view, patients should be labeled as 'Compliant', 'Semi-Compliant', 'Non-Compliant' or 'Unknown'

![compliance-unkown](https://cloud.githubusercontent.com/assets/3107513/13577030/b677b292-e44d-11e5-94b0-47adfac69bb9.png)
