### PR TITLE
Changed survey_template names

### DIFF
--- a/task/helper/seed-data.js
+++ b/task/helper/seed-data.js
@@ -33,11 +33,11 @@ module.exports.trial = [
 module.exports.surveyTemplate = [
     {
         id: 1,
-        name: 'Sickle Cell Survey'
+        name: 'Sickle Cell Weekly Survey'
     },
     {
         id: 2,
-        name: 'Post Op Survey'
+        name: 'Post Op Weekly Survey'
     },
     {
         id: 3,


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story:** None

**Taiga Task(s):** None

**What did you change?**
- Changed the survey_template names to provide more clarity on whether they are weekly surveys or not. Now the templates which are weekly have the word "Weekly" in the name field.

**How can we test?**
- If you have a test pin in 4000 series and if you have a weekly survey due then you should be able to see the message on the app with survey name as : "Post Op Weekly Survey"
- If you have a test pin in 4000 series with a daily survey due then you should be able to see the message on the app with survey name as : "Post Op Pain Reporting Survey"
- If you have a pin in the 2000 series and if you have a survey due then you should be able to see the message on the app with survey name as : "Sickle Cell Weekly Survey"
