### PR TITLE
Rename Patient Status

### DIFF
--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -112,7 +112,7 @@ function trialView (request, reply) {
                     patient.status = patientStatus.status;
                     patient.totalMissed = patientStatus.expiredCount;
                 } else {
-                    patient.status = 'Unknown';
+                    patient.status = 'Pending';
                     patient.totalMissed = 0;
                 }
 


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story:** None

**Taiga Task(s):** None

**What did you change?**
When for patients with no compliance data is available for this week, their status should show as 'pending'.

**How can we test?**
View trial page, check that patients with no weekly survey instances show as 'pending' not 'unknown'

![pending](https://cloud.githubusercontent.com/assets/3107513/13588827/3222d178-e490-11e5-8ed3-6cdf5d5be5a8.PNG)
