### PR TITLE
Project only used values in queries - Part 1

### DIFF
--- a/controller/handler/patient-csv.js
+++ b/controller/handler/patient-csv.js
@@ -45,7 +45,7 @@ const configuration = [
 function patientCSV (request, reply) {
     database.sequelize.query(
         `
-        SELECT *, si.id, qt.id AS questionId, qo.id AS optionId
+        SELECT pa.pin, st.name, si.id, qt.id AS questionId, qt.questionText, qo.id AS optionId, qo.optionText
         FROM patient AS pa
         JOIN survey_instance AS si
         ON si.patientId = pa.id
@@ -73,9 +73,9 @@ function patientCSV (request, reply) {
     )
     .then((optionsWithAnswers) => {
         const property = ['pin', 'name', 'id', 'questionText', 'questionId'];
-        const rowsm = deduplicate(optionsWithAnswers, property);
+        const uniqueAnswers = deduplicate(optionsWithAnswers, property);
 
-        return convertJsonToCsv(rowsm, configuration);
+        return convertJsonToCsv(uniqueAnswers, configuration);
     })
     .then((csv) => {
         reply(csv).type('text/csv');

--- a/rule/task/run-survey-rules.js
+++ b/rule/task/run-survey-rules.js
@@ -20,20 +20,18 @@ function runSurveyRules () {
     .sequelize
     .query(
        `
-       SELECT *, pa.id AS patientId
+       SELECT pa.id, pa.dateStarted, jss.surveyTemplateId, jss.rule
        FROM patient AS pa
        JOIN stage AS st
        ON st.id = pa.stageId
        JOIN join_stages_and_surveys AS jss
        ON jss.stageId = st.id
-       WHERE pa.dateStarted < ?
-       AND pa.dateCompleted > ?
+       WHERE ? BETWEEN pa.dateStarted AND pa.dateCompleted
        ORDER BY pa.id, jss.stagePriority
        `,
         {
             type: database.sequelize.QueryTypes.SELECT,
             replacements: [
-                currentDate,
                 currentDate
             ]
         }
@@ -89,7 +87,7 @@ function isActive (rule) {
  * @returns {Boolean} true for same, false for different
  */
 function isSamePatient (first, second) {
-    return first.patientId === second.patientId;
+    return first.id === second.id;
 }
 
 /**
@@ -107,7 +105,7 @@ function toSurveyInstanceData (row) {
     }
 
     return {
-        patientId: row.patientId,
+        patientId: row.id,
         surveyTemplateId: row.surveyTemplateId,
         state: 'pending',
         startTime: moment()


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story**
None

**Taiga Task(s)**
None

**Why did you change?**
Current queries return `*`, which includes all attributes.
Selecting only the columns that are actually used can greatly reduce the data transfer to pass the data back to Sequelize/Node.js

**What did you change?**
Updated Survey Scheduler and Patient CSV export.

**How can we test?**
* Run scheduler, instances should be created correctly
* Run export CSV should generate correctly