### PR TITLE
Support TLS

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -146,7 +146,7 @@ rules:
     no-process-exit: error
     no-restricted-imports: off # none
     no-restricted-modules: off # none
-    no-sync: error
+    no-sync: warn
 
     # Stylistic Issues
     array-bracket-spacing: error
@@ -185,7 +185,9 @@ rules:
         - error
         - 2
     max-params: error
-    max-statements: error
+    max-statements:
+        - error
+        - 20
     new-cap: error
     new-parens: error
     newline-after-var: error

--- a/api/server.js
+++ b/api/server.js
@@ -5,6 +5,7 @@
  */
 
 // load node modules
+const fs = require('fs');
 const hapi = require('hapi');
 
 // load router and database
@@ -18,12 +19,23 @@ const database = require('../model');
  */
 function apiServer (configuration) {
     const server = new hapi.Server();
-
-    // configure server connection
-    server.connection({
+    const connectionOptions = {
         port: configuration.api.port,
         host: configuration.api.hostname
-    });
+    };
+
+    if (configuration.tls) {
+        connectionOptions.tls = {
+            key: fs.readFileSync(configuration.tls.key),
+            cert: fs.readFileSync(configuration.tls.cert)
+        };
+        if (configuration.tls.passphrase) {
+            connectionOptions.tls.passphrase = configuration.tls.passphrase;
+        }
+    }
+
+    // configure server connection
+    server.connection(connectionOptions);
 
     // configure database connection
     database.setup(configuration.database);

--- a/controller/handler/.eslintrc.yml
+++ b/controller/handler/.eslintrc.yml
@@ -6,6 +6,3 @@ rules:
     max-nested-callbacks:
         - error
         - 3
-    max-statements:
-        - error
-        - 20

--- a/controller/helper/.eslintrc.yml
+++ b/controller/helper/.eslintrc.yml
@@ -3,7 +3,3 @@ rules:
     max-params:
         - error
         - 6
-
-    max-statements:
-        - error
-        - 20

--- a/controller/server.js
+++ b/controller/server.js
@@ -5,6 +5,7 @@
  */
 
 // load node modules
+const fs = require('fs');
 const path = require('path');
 const hapi = require('hapi');
 const vision = require('vision');
@@ -24,12 +25,23 @@ const validate = require('./helper/validate');
  */
 function dashboardServer (configuration) {
     const server = new hapi.Server();
-
-    // configure server connection
-    server.connection({
+    const connectionOptions = {
         port: configuration.dashboard.port,
         host: configuration.dashboard.hostname
-    });
+    };
+
+    if (configuration.tls) {
+        connectionOptions.tls = {
+            key: fs.readFileSync(configuration.tls.key),
+            cert: fs.readFileSync(configuration.tls.cert)
+        };
+        if (configuration.tls.passphrase) {
+            connectionOptions.tls.passphrase = configuration.tls.passphrase;
+        }
+    }
+
+    // configure server connection
+    server.connection(connectionOptions);
 
     // register hapi plugins
     server.register(

--- a/model/.eslintrc.yml
+++ b/model/.eslintrc.yml
@@ -1,4 +1,3 @@
 rules:
     global-require: warn
-    max-statements: off
-    no-sync: off
+    max-statements: warn

--- a/task/validate-configuration.js
+++ b/task/validate-configuration.js
@@ -47,7 +47,18 @@ const schema = Joi
         environment: Joi
             .string()
             .lowercase()
-            .token()
+            .token(),
+        tls: Joi
+            .object({
+                cert: Joi
+                    .string(),
+                key: Joi
+                    .string(),
+                passphrase: Joi
+                    .string()
+                    .optional()
+            })
+            .optional()
     })
     .assert(
         'api.port',

--- a/view/.eslintrc.yml
+++ b/view/.eslintrc.yml
@@ -34,9 +34,6 @@ rules:
     # Stylistic Issues
     require-jsdoc: off
     spaced-comment: off
-    max-statements:
-        - error
-        - 20
 
     # ECMAScript 6
     no-var: off


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story**
504

**Taiga Task(s)**
N/A

**What did you change?**
Added support for passing a TLS key, cert and passphrase into Node.js
Server will still support plain HTTP.
~~When HTTPS is enabled HTTP connections will automatically be forwarded.~~

NOTE: tls is optional, it does not need to be set.
NOTE: when TLS is set passphrase is optional, key and cert are required

**How can we test?**
Add a TLS section to the `config.json`

Example config
``` json
{
  "environment": "development",
  "dashboard": {
    "hostname": "localhost",
    "port": 3000
  },
  "api": {
    "hostname": "localhost",
    "port": 3001
  },
  "database": {
    "hostname": "localhost",
    "name": "prp_development",
    "username": "tester",
    "password": "test",
    "dialect": "mysql",
    "salt": "something secure here"
  },
  "tls": {
    "passphrase": "test",
    "key": "/absolute/path/to/key.pem",
    "cert": "/absolute/path/to/cert.pem"
  }
}
```
