### PR TITLE
Removed the UTC conversion as sequelize takes care of converting data…

### DIFF
--- a/controller/handler/patient.js
+++ b/controller/handler/patient.js
@@ -84,13 +84,13 @@ function patientView (request, reply) {
                     const surveyInstanceCopy = Object.assign({}, surveyInstance);
 
                     surveyInstanceCopy.startTime = moment(surveyInstanceCopy.startTime, sqlDateFormat)
-                        .utc().format('MM-DD-YYYY');
+                        .format('MM-DD-YYYY');
                     surveyInstanceCopy.endTime = moment(surveyInstanceCopy.endTime, sqlDateFormat)
-                        .utc().format('MM-DD-YYYY');
+                        .format('MM-DD-YYYY');
                     if (surveyInstanceCopy.userSubmissionTime) {
                         surveyInstanceCopy.userSubmissionTime
                             = moment(surveyInstanceCopy.userSubmissionTime, sqlDateFormat)
-                                .utc().format('MM-DD-YYYY h:mma');
+                                .format('MM-DD-YYYY h:mma');
                     }
 
                     return surveyInstanceCopy;

--- a/controller/helper/process-survey-instances.js
+++ b/controller/helper/process-survey-instances.js
@@ -20,7 +20,6 @@ function processSurveyInstances (surveys) {
     });
 
     return {
-        // Using UTC as the date gets modified to the local time (GMT in this case) when UTC not used.
         labels: pickDates(filterSurveyByState),
         datasets: pickTimeLeft(filterSurveyByState)
     };
@@ -33,11 +32,11 @@ function processSurveyInstances (surveys) {
  */
 function pickDates (surveys) {
     const dates = surveys.map((survey) => {
-        return moment(survey.startTime, sqlDateFormat).utc().format(viewDateFormat);
+        return moment(survey.startTime, sqlDateFormat).format(viewDateFormat);
     });
 
     if (surveys[0]) {
-        dates.push(moment(surveys[0].dateCompleted, sqlDateFormat).utc().format(viewDateFormat));
+        dates.push(moment(surveys[0].dateCompleted, sqlDateFormat).format(viewDateFormat));
     }
 
     return dates;
@@ -49,12 +48,11 @@ function pickDates (surveys) {
  * @returns {Object} processed list of % time left data
  */
 function pickTimeLeft (surveys) {
-    // Using UTC as the date gets modified to the local time (GMT in this case) when UTC not used.
     const percentages = surveys.map((survey) => {
         return calculateTimeLeft(
-            moment(survey.startTime, sqlDateFormat).utc().format(viewDateFormat),
-            moment(survey.endTime, sqlDateFormat).utc().format(viewDateFormat),
-            moment(survey.actualSubmissionTime, sqlDateFormat).utc().format(viewDateFormat)
+            moment(survey.startTime, sqlDateFormat).format(viewDateFormat),
+            moment(survey.endTime, sqlDateFormat).format(viewDateFormat),
+            moment(survey.actualSubmissionTime, sqlDateFormat).format(viewDateFormat)
         );
     });
 


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story** - 509

**Taiga Task(s)** - 526, 540

**What did you change?** - Removed the UTC conversion wherever used in the application. As the sequelize will convert the timezone to UTC while saving into DB and to local timezone while retrieving from DB, we don't need this additional conversion.

**How can we test?** - Any date saved in DB should be 7 hrs ahead of the same date in UI (for MST timezone). One specific case can be, 
  1. enroll new patient in SCD weekly.
  2. complete the survey after 5pm on the first day.
  Output - the displayed date of completion should be same as first date and percentage should be calculated accordingly.

… to the required format while saving and fetching.