### PR TITLE
Fixed issue #308

### DIFF
--- a/api/handler/submit-survey.js
+++ b/api/handler/submit-survey.js
@@ -84,7 +84,7 @@ function submitSurvey (request, reply) {
                     questionOption.find(
                         {
                             where: {
-                                optionText: currentQuestion.bodyPain[0].intensity
+                                optionText: currentQuestion.bodyPain[0].intensity.toString()
                             },
                             transaction
                         }


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Github Issue**
#308 

**What did you change?**
Converted the bodyPain.intensity value to string before querying it in the question_option table.
This will pick up the correct value from the DB and save it in question_result table.
This resolves the issue #308 
**How can we test?**
Take a PIN which has a survey due today.
Choose "No Pain" for the body Pain question.
Fill the rest of the survey and submit.
Check in the DB question_result table for bodyPain question, No Pain and 0 are the question_options saved.

