### PR TITLE
Updated the patient duration to 12 weeks for SCD trial

### DIFF
--- a/task/helper/seed-data.js
+++ b/task/helper/seed-data.js
@@ -1599,7 +1599,7 @@ module.exports.joinStagesAndSurveys = [
 
 module.exports.joinCurrentAndNextStage = [
     {
-        rule: 35,
+        rule: 84,
         stageId: 1,
         nextStageId: 6
     },


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story**
Tg-642

**Taiga Task(s)**
Tg-643

**What did you change?**
Set the rule to 84 days i.e 12 weeks in join_current_and_next_stages table.
This will keep the default patient duration under SCD trial to be set as 12 weeks.
**How can we test?**
Enroll a new patient in SCD trial.
Check that the difference between patient start date and patient end date by default shows 12 weeks.
