### PR TITLE
Deactivate Patient Inline

### DIFF
--- a/api/handler/check-surveys.js
+++ b/api/handler/check-surveys.js
@@ -50,6 +50,7 @@ function checkSurveys (request, reply) {
             ON si.surveyTemplateId = st.id
             WHERE pa.pin = ?
             AND ? BETWEEN si.startTime AND si.endTime
+            AND pa.deletedAt IS NULL
             AND (
                 si.state = 'pending'
                 OR si.state = 'in progress'

--- a/api/handler/check-surveys.js
+++ b/api/handler/check-surveys.js
@@ -44,13 +44,12 @@ function checkSurveys (request, reply) {
             `
             SELECT *, si.id
             FROM survey_instance AS si
-            JOIN patient AS pa
+            JOIN active_patients AS pa
             ON si.patientId = pa.id
             JOIN survey_template AS st
             ON si.surveyTemplateId = st.id
             WHERE pa.pin = ?
             AND ? BETWEEN si.startTime AND si.endTime
-            AND pa.deletedAt IS NULL
             AND (
                 si.state = 'pending'
                 OR si.state = 'in progress'

--- a/controller/handler-test/deactivate-patient.js
+++ b/controller/handler-test/deactivate-patient.js
@@ -49,3 +49,87 @@ test.cb('when patient exists', (t) => {
 
     deactivatePatient(request, reply);
 });
+
+test.cb('when patient does not exist', (t) => {
+    const model = sinon.stub();
+    const transaction = sinon.stub();
+
+    model
+    .withArgs('patient')
+    .returns({
+        findOne () {
+            return null;
+        }
+    });
+
+    transaction.returns(Promise.resolve({
+        rollback () {
+            return Promise.resolve();
+        }
+    }));
+
+    const deactivatePatient = proxyquire('../handler/deactivate-patient', {
+        '../../model': {
+            sequelize: {
+                model,
+                transaction
+            }
+        }
+    });
+
+    const request = {
+        log: sinon.stub(),
+        params: {
+            pin: 1
+        }
+    };
+
+    const reply = () => {
+        t.pass('it should resolve');
+        t.end();
+    };
+
+    deactivatePatient(request, reply);
+});
+
+test.cb('when there is a conflict', (t) => {
+    const model = sinon.stub();
+    const transaction = sinon.stub();
+
+    model
+    .withArgs('patient')
+    .returns({
+        findOne () {
+            return Promise.reject();
+        }
+    });
+
+    transaction.returns(Promise.resolve({
+        rollback () {
+            return Promise.resolve();
+        }
+    }));
+
+    const deactivatePatient = proxyquire('../handler/deactivate-patient', {
+        '../../model': {
+            sequelize: {
+                model,
+                transaction
+            }
+        }
+    });
+
+    const request = {
+        log: sinon.stub(),
+        params: {
+            pin: 1
+        }
+    };
+
+    const reply = (data) => {
+        t.is(data.name, 'Error', 'it should have error object');
+        t.end();
+    };
+
+    deactivatePatient(request, reply);
+});

--- a/controller/handler-test/deactivate-patient.js
+++ b/controller/handler-test/deactivate-patient.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+test.cb('when patient exists', (t) => {
+    const model = sinon.stub();
+    const transaction = sinon.stub();
+
+    model
+    .withArgs('patient')
+    .returns({
+        findOne () {
+            return {
+                destroy () {
+                    return;
+                }
+            };
+        }
+    });
+
+    transaction.returns(Promise.resolve({
+        commit () {
+            return Promise.resolve();
+        }
+    }));
+
+    const deactivatePatient = proxyquire('../handler/deactivate-patient', {
+        '../../model': {
+            sequelize: {
+                model,
+                transaction
+            }
+        }
+    });
+
+    const request = {
+        log: sinon.stub(),
+        params: {
+            pin: 1
+        }
+    };
+
+    const reply = () => {
+        t.pass('it should resolve');
+        t.end();
+    };
+
+    deactivatePatient(request, reply);
+});

--- a/controller/handler/dashboard.js
+++ b/controller/handler/dashboard.js
@@ -24,29 +24,26 @@ function dashboardView (request, reply) {
         LEFT JOIN (
         	SELECT st.trialId, COUNT(pa.id) AS recruitedCount
         	FROM stage AS st
-        	JOIN patient AS pa
+        	JOIN active_patients AS pa
         	ON pa.stageId = st.id
-            WHERE pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS recruited
         ON tr.id = recruited.trialId
         LEFT JOIN (
         	SELECT st.trialId, COUNT(pa.id) AS completedCount
         	FROM stage AS st
-        	JOIN patient AS pa
+        	JOIN active_patients AS pa
         	ON pa.stageId = st.id
         	WHERE pa.dateCompleted < ?
-            AND pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS completed
         ON tr.id = completed.trialId
         LEFT JOIN (
         	SELECT st.trialId, COUNT(pa.id) AS activeCount
         	FROM stage AS st
-        	JOIN patient AS pa
+        	JOIN active_patients AS pa
         	ON pa.stageId = st.id
         	WHERE ? BETWEEN pa.dateStarted AND pa.dateCompleted
-            AND pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS active
         ON tr.id = active.trialId;

--- a/controller/handler/dashboard.js
+++ b/controller/handler/dashboard.js
@@ -26,6 +26,7 @@ function dashboardView (request, reply) {
         	FROM stage AS st
         	JOIN patient AS pa
         	ON pa.stageId = st.id
+            WHERE pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS recruited
         ON tr.id = recruited.trialId
@@ -35,6 +36,7 @@ function dashboardView (request, reply) {
         	JOIN patient AS pa
         	ON pa.stageId = st.id
         	WHERE pa.dateCompleted < ?
+            AND pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS completed
         ON tr.id = completed.trialId
@@ -44,6 +46,7 @@ function dashboardView (request, reply) {
         	JOIN patient AS pa
         	ON pa.stageId = st.id
         	WHERE ? BETWEEN pa.dateStarted AND pa.dateCompleted
+            AND pa.deletedAt IS NULL
         	GROUP BY st.trialId
         ) AS active
         ON tr.id = active.trialId;

--- a/controller/handler/deactivate-patient.js
+++ b/controller/handler/deactivate-patient.js
@@ -37,7 +37,7 @@ function deactivatePatient (request, reply) {
         return transaction.commit();
     })
     .then(() => {
-        return reply.redirect('/');
+        return reply();
     })
     .catch((err) => {
         request.log('error', err);

--- a/controller/handler/deactivate-patient.js
+++ b/controller/handler/deactivate-patient.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * @module controller/handler/deactivate-patient
+ */
+
+const boom = require('boom');
+const database = require('../../model');
+
+/**
+ * Deactivates a patient
+ * @param {Request} request - Hapi request
+ * @param {Reply} reply - Hapi Reply
+ * @returns {Null} Redirect
+ */
+function deactivatePatient (request, reply) {
+    const patient = database.sequelize.model('patient');
+    let transaction = null;
+
+    database
+    .sequelize
+    .transaction()
+    .then((newTransaction) => {
+        transaction = newTransaction;
+
+        return patient.findOne({
+            where: {
+                pin: request.params.pin
+            },
+            transaction
+        });
+    })
+    .then((currentPatient) => {
+        return currentPatient.destroy({transaction});
+    })
+    .then(() => {
+        return transaction.commit();
+    })
+    .then(() => {
+        return reply.redirect('/');
+    })
+    .catch((err) => {
+        request.log('error', err);
+        transaction.rollback();
+
+        return reply(boom.conflict());
+    });
+}
+
+module.exports = deactivatePatient;

--- a/controller/handler/patient-csv.js
+++ b/controller/handler/patient-csv.js
@@ -51,7 +51,7 @@ function patientCSV (request, reply) {
     database.sequelize.query(
         `
         SELECT pa.pin, st.name, si.id, qt.id AS questionId, qt.questionText, qo.id AS optionId, qo.optionText
-        FROM patient AS pa
+        FROM active_patients AS pa
         JOIN survey_instance AS si
         ON si.patientId = pa.id
         JOIN survey_template AS st
@@ -67,7 +67,6 @@ function patientCSV (request, reply) {
         AND qr.questionOptionId = qo.id
         WHERE pa.pin = ?
         AND si.state = 'completed'
-        AND pa.deletedAt IS NULL
         ORDER BY si.id, jsq.questionOrder, qo.order
         `,
         {

--- a/controller/handler/patient-csv.js
+++ b/controller/handler/patient-csv.js
@@ -66,7 +66,8 @@ function patientCSV (request, reply) {
         ON qr.surveyInstanceId = si.id
         AND qr.questionOptionId = qo.id
         WHERE pa.pin = ?
-        and si.state = 'completed'
+        AND si.state = 'completed'
+        AND pa.deletedAt IS NULL
         ORDER BY si.id, jsq.questionOrder, qo.order
         `,
         {

--- a/controller/handler/patient.js
+++ b/controller/handler/patient.js
@@ -26,6 +26,7 @@ function patientView (request, reply) {
                 JOIN stage AS st
                 ON st.id = pa.stageId
                 WHERE pa.pin = ?
+                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,
@@ -48,6 +49,7 @@ function patientView (request, reply) {
                 JOIN survey_template AS srt
                 ON srt.id = si.surveyTemplateId
                 WHERE pa.pin = ?
+                AND pa.deletedAt IS NULL
                 ORDER BY si.startTime
                 `,
                 {
@@ -66,6 +68,7 @@ function patientView (request, reply) {
                 JOIN trial AS tr
                 ON tr.id = st.trialId
                 WHERE pa.pin = ?
+                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,

--- a/controller/handler/patient.js
+++ b/controller/handler/patient.js
@@ -22,11 +22,10 @@ function patientView (request, reply) {
             database.sequelize.query(
                 `
                 SELECT pa.pin, st.name AS stage
-                FROM patient AS pa
+                FROM active_patients AS pa
                 JOIN stage AS st
                 ON st.id = pa.stageId
                 WHERE pa.pin = ?
-                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,
@@ -41,7 +40,7 @@ function patientView (request, reply) {
                 SELECT pa.dateCompleted, si.id, si.startTime, si.endTime, si.userSubmissionTime,
                 si.actualSubmissionTime, si.state, si.surveyTemplateId, st.name AS stageName,
                 srt.name AS surveyTemplateName
-                FROM patient AS pa
+                FROM active_patients AS pa
                 JOIN survey_instance AS si
                 ON si.patientId = pa.id
                 JOIN stage AS st
@@ -49,7 +48,6 @@ function patientView (request, reply) {
                 JOIN survey_template AS srt
                 ON srt.id = si.surveyTemplateId
                 WHERE pa.pin = ?
-                AND pa.deletedAt IS NULL
                 ORDER BY si.startTime
                 `,
                 {
@@ -62,13 +60,12 @@ function patientView (request, reply) {
             database.sequelize.query(
                 `
                 SELECT tr.name, tr.id
-                FROM patient AS pa
+                FROM active_patients AS pa
                 JOIN stage AS st
                 ON st.id = pa.stageId
                 JOIN trial AS tr
                 ON tr.id = st.trialId
                 WHERE pa.pin = ?
-                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,

--- a/controller/handler/survey.js
+++ b/controller/handler/survey.js
@@ -56,6 +56,7 @@ function surveyView (request, reply) {
             JOIN trial AS tr
             ON tr.id = st.trialId
             WHERE si.id = ?
+            AND pa.deletedAt IS NULL
             `,
             {
                 type: database.sequelize.QueryTypes.SELECT,

--- a/controller/handler/survey.js
+++ b/controller/handler/survey.js
@@ -49,14 +49,13 @@ function surveyView (request, reply) {
             `
             SELECT pa.pin, tr.id, tr.name
             FROM survey_instance AS si
-            JOIN patient AS pa
+            JOIN active_patients AS pa
             ON pa.id = si.patientId
             JOIN stage as st
             ON st.id = pa.stageId
             JOIN trial AS tr
             ON tr.id = st.trialId
             WHERE si.id = ?
-            AND pa.deletedAt IS NULL
             `,
             {
                 type: database.sequelize.QueryTypes.SELECT,

--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -38,10 +38,9 @@ function trialView (request, reply) {
                 FROM trial AS tr
                 JOIN stage AS st
                 ON st.trialId = tr.id
-                JOIN patient AS pa
+                JOIN active_patients AS pa
                 ON pa.stageId = st.id
                 WHERE tr.id = ?
-                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,
@@ -56,14 +55,13 @@ function trialView (request, reply) {
                 SUM(si.state = 'expired') AS expiredCount,
                 SUM(si.state = 'completed') AS completedCount
                 FROM survey_instance AS si
-                JOIN patient AS pa
+                JOIN active_patients AS pa
                 ON pa.id = si.patientId
                 JOIN stage AS st
                 ON st.id = pa.stageId
                 WHERE st.trialId = ?
                 AND si.startTime >= ?
                 AND si.endTime <= ?
-                AND pa.deletedAt IS NULL
                 GROUP BY pa.id
                 `,
                 {

--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -41,6 +41,7 @@ function trialView (request, reply) {
                 JOIN patient AS pa
                 ON pa.stageId = st.id
                 WHERE tr.id = ?
+                AND pa.deletedAt IS NULL
                 `,
                 {
                     type: database.sequelize.QueryTypes.SELECT,
@@ -62,6 +63,7 @@ function trialView (request, reply) {
                 WHERE st.trialId = ?
                 AND si.startTime >= ?
                 AND si.endTime <= ?
+                AND pa.deletedAt IS NULL
                 GROUP BY pa.id
                 `,
                 {

--- a/controller/router.js
+++ b/controller/router.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 
 const createTrial = require('./handler/create-trial');
 const createPatient = require('./handler/create-patient');
+const deactivatePatient = require('./handler/deactivate-patient');
 const dashboardPresenter = require('./handler/dashboard');
 const trialPresenter = require('./handler/trial');
 const patientPresenter = require('./handler/patient');
@@ -152,6 +153,21 @@ module.exports = [
         method: 'GET',
         path: '/patient/{pin}',
         handler: patientPresenter,
+        config: {
+            validate: {
+                params: {
+                    pin: Joi
+                        .number()
+                        .integer()
+                        .positive()
+                }
+            }
+        }
+    },
+    {
+        method: 'DELETE',
+        path: '/patient/{pin}',
+        handler: deactivatePatient,
         config: {
             validate: {
                 params: {

--- a/model/index.js
+++ b/model/index.js
@@ -24,6 +24,9 @@ const addJoinStagesAndSurveys = require('./join-stages-and-surveys');
 const addJoinSurveysAndQuestions = require('./join-surveys-and-questions');
 const addJoinCurrentAndNextStages = require('./join-current-and-next-stages');
 
+// Database Views
+const addViewActivePatients = require('./view-active-patients');
+
 /**
  * a DatabaseConfiguration is a collection of the settings needed to connect to the database.
  * @typedef {Object} DatabaseConfiguration
@@ -69,6 +72,9 @@ function setup (configuration) {
     addJoinStagesAndSurveys(sequelize);
     addJoinSurveysAndQuestions(sequelize);
     addJoinCurrentAndNextStages(sequelize);
+
+    // add the database views
+    addViewActivePatients(sequelize);
 
     // Get the newly created ORM wrappers
     const user = sequelize.model('user');

--- a/model/view-active-patients.js
+++ b/model/view-active-patients.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Registers view with Sequelize
+ * @param {Sequelize} sequelize - database instance
+ * @param {String} salt - salt value to use when hashing password
+ * @returns {Null} nothing
+ */
+function register (sequelize) {
+    /**
+     * patient that has not been deactivated
+     * @typedef {Object} ActivePatient
+     */
+    sequelize.query(
+        `
+        CREATE OR REPLACE VIEW active_patients AS
+        SELECT *
+        FROM patient
+        WHERE deletedAt IS NULL
+        `,
+        {
+            raw: true
+        }
+    );
+}
+
+module.exports = register;

--- a/rule/task/run-survey-rules.js
+++ b/rule/task/run-survey-rules.js
@@ -27,6 +27,7 @@ function runSurveyRules () {
        JOIN join_stages_and_surveys AS jss
        ON jss.stageId = st.id
        WHERE ? BETWEEN pa.dateStarted AND pa.dateCompleted
+       AND pa.deletedAt IS NULL
        ORDER BY pa.id, jss.stagePriority
        `,
         {

--- a/rule/task/run-survey-rules.js
+++ b/rule/task/run-survey-rules.js
@@ -21,13 +21,12 @@ function runSurveyRules () {
     .query(
        `
        SELECT pa.id, pa.dateStarted, jss.surveyTemplateId, jss.rule
-       FROM patient AS pa
+       FROM active_patients AS pa
        JOIN stage AS st
        ON st.id = pa.stageId
        JOIN join_stages_and_surveys AS jss
        ON jss.stageId = st.id
        WHERE ? BETWEEN pa.dateStarted AND pa.dateCompleted
-       AND pa.deletedAt IS NULL
        ORDER BY pa.id, jss.stagePriority
        `,
         {

--- a/view/script/patient.js
+++ b/view/script/patient.js
@@ -62,6 +62,24 @@
 
     var ctx = document.getElementById('complianceChart').getContext('2d');
 
+    function redirect () {
+        window.location = '/';
+    }
+
+    function warningMessage () {
+        alert('patient could not be deactivated');
+    }
+
+    document.getElementById('deactivate-patient')
+    .addEventListener('click', function deactivate () {
+        $.ajax({
+            url: window.location.pathname,
+            type: 'DELETE'
+        })
+        .done(redirect)
+        .fail(warningMessage);
+    });
+
     if (isNewPatientRegex.test(isNewPatient)) {
         $('#remember-patient-dialog').modal('show');
     }

--- a/view/template/patient.hbs
+++ b/view/template/patient.hbs
@@ -27,9 +27,14 @@
                 <div class="card-block">
                     <h4 class="card-title">
                         Patients' Surveys
-                        <a href="/patient/{{ patient.pin }}.csv" class="btn btn-primary btn-sm pull-right">
-                            Export Patient Data
-                        </a>
+                        <span class="pull-right">
+                            <a href="/patient/{{ patient.pin }}.csv" class="btn btn-primary btn-sm">
+                                Export Patient Data
+                            </a>
+                            <button id="deactivate-patient" class="btn btn-danger btn-sm">
+                                Deactivate
+                            </button>
+                        </span>
                     </h4>
                     <div class="table-responsive">
                         <table class="table table-striped">


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story**
TG-634

**Taiga Task(s)**
TG-651

**What did you change?**
Allowed Patient to be deactivated.
Ensure that patient is active in all patient related queries.

**How can we test?**
Go to the patient view.
Click "deactivate"
Go back to the trial view.
Patient should not appear.

**Discussion**
This is based on the design idea originally intended when the current schema was setup.
All tables have a `deletedAt` column, that when a row is soft deleted, will be set to the current date time.

This implementation sets that column when deactivating a patient, and ensures that all queries related to patient ignore deactivated patients.

This is different from the approach that @kgary  suggested where patients would be copied to an external table/database.

I already had some code for it ready to go, so I'm putting it out there as an option.
This could also be redone in the approach suggested by @kgary

Thoughts? :thought_balloon: 