### PR TITLE
Us#635  As a clinician, I would like to see the expected patient duration for the trial

### DIFF
--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -11,7 +11,6 @@ const processComplianceCount = require('../helper/process-compliance-count');
 const processRules = require('../helper/process-rules');
 const processPatientStatus = require('../helper/process-patient-status');
 const httpNotFound = 404;
-const sqlDateFormat = 'ddd MMM DD YYYY HH:mm:ss ZZ';
 
 /**
  * A dashboard with an overview of a specific trial.
@@ -122,9 +121,9 @@ function trialView (request, reply) {
                     patient.totalMissed = 0;
                 }
 
-                patient.dateStarted = moment(patient.dateStarted, sqlDateFormat)
+                patient.dateStarted = moment(patient.dateStarted)
                     .format('MM-DD-YYYY');
-                patient.dateCompleted = moment(patient.dateCompleted, sqlDateFormat)
+                patient.dateCompleted = moment(patient.dateCompleted)
                     .format('MM-DD-YYYY');
 
                 return patient;

--- a/controller/handler/trial.js
+++ b/controller/handler/trial.js
@@ -11,6 +11,7 @@ const processComplianceCount = require('../helper/process-compliance-count');
 const processRules = require('../helper/process-rules');
 const processPatientStatus = require('../helper/process-patient-status');
 const httpNotFound = 404;
+const sqlDateFormat = 'ddd MMM DD YYYY HH:mm:ss ZZ';
 
 /**
  * A dashboard with an overview of a specific trial.
@@ -33,7 +34,7 @@ function trialView (request, reply) {
             }),
             database.sequelize.query(
                 `
-                SELECT tr.*, pa.pin, st.name AS stage
+                SELECT tr.*, pa.pin, pa.dateStarted, pa.dateCompleted, st.name AS stage
                 FROM trial AS tr
                 JOIN stage AS st
                 ON st.trialId = tr.id
@@ -120,6 +121,11 @@ function trialView (request, reply) {
                     patient.status = 'Pending';
                     patient.totalMissed = 0;
                 }
+
+                patient.dateStarted = moment(patient.dateStarted, sqlDateFormat)
+                    .format('MM-DD-YYYY');
+                patient.dateCompleted = moment(patient.dateCompleted, sqlDateFormat)
+                    .format('MM-DD-YYYY');
 
                 return patient;
             });

--- a/view/template/trial.hbs
+++ b/view/template/trial.hbs
@@ -102,6 +102,12 @@
                                     Stage
                                 </th>
                                 <th>
+                                    Start
+                                </th>
+                                <th>
+                                    End
+                                </th>
+                                <th>
                                     Total Missed Past Week
                                 </th>
                             </tr>
@@ -134,6 +140,12 @@
                                     </td>
                                     <td>
                                         {{ stage }}
+                                    </td>
+                                    <td>
+                                        {{ dateStarted }}
+                                    </td>
+                                    <td>
+                                        {{ dateCompleted }}
                                     </td>
                                     <td>
                                         {{ totalMissed }}


### PR DESCRIPTION
**Taiga User Story**
Us#635  As a clinician, I would like to see the expected patient duration for the trial
**Taiga Task(s)**
#656 add patient's start and end date on trial page
**What did you change?**
I changed the query to fetch patient's list registered to trial. 
I changed the view to show fetched "Start" and "End" Date of patient   
**How can we test?**
1. go to any trial view
2. view the enlisted patient's data
3. you will find two extra fields [Start , End] as part of tabular view

![screen shot 2016-04-22 at 10 37 18 am](https://cloud.githubusercontent.com/assets/5720497/14749798/65dc1312-0876-11e6-8b3a-5907bffe0223.png)

