### PR TITLE
Displaying all the dates in the chart

### DIFF
--- a/controller/helper/process-survey-instances.js
+++ b/controller/helper/process-survey-instances.js
@@ -36,7 +36,12 @@ function pickDates (surveys) {
     });
 
     if (surveys[0]) {
-        dates.push(moment(surveys[0].dateCompleted, sqlDateFormat).format(viewDateFormat));
+        // Adding an additional week to include all the dates in compliance chart.
+        // This is done because chart js plots only the first day of the week.
+        const numberOfDays = 7;
+        const endDateforChart = moment(surveys[0].dateCompleted).add(numberOfDays, 'day');
+
+        dates.push(moment(endDateforChart, sqlDateFormat).format(viewDateFormat));
     }
 
     return dates;


### PR DESCRIPTION
<!--
1. Ensure Pull Request is targeting the `development` branch
2. Provide the requested information
-->
**Taiga User Story** 635

**Taiga Task(s)** 660

**What did you change?** When including the DateCompleted date in the set of labels to be displayed on the x-axis of the compliance chart, we now add a week's duration to it. This is because the chart js plots only the starting date of a week.

**How can we test?**
Load the compliance chart and it should now include the dateCompleted associated with a patient.
